### PR TITLE
RELEASE: modification for first release

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,4 +16,16 @@ val a: Int? = try { input.toInt() } catch (e: NumberFormatException) { null }
 Quote: https://kotlinlang.org/docs/exceptions.html#try-is-an-expression
 
 # Usage
+## try-catch
+### Basic usage
+```typescript
+const r = doOnTry(() => (new ErrorService().execute()),
+        recover(Error.prototype, (e: Error) => ('DEFAULT')))
+```
 
+## if-else
+### Basic usage
+```typescript
+const r = If(base.length > 30, () => 'over 30')
+        .else(() => 'under 30')
+```

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
 export {If} from './if';
-export {Try, Catch} from './try';
+export {doOnTry, recover} from './try';

--- a/src/try.ts
+++ b/src/try.ts
@@ -2,8 +2,8 @@
  * Expression closure definition.
  */
 type ExpressionState<T> = {
-  e: typeof Error,
-  f: (e?: Error) => T
+  e: Error,
+  f: (e: Error) => T
 }
 
 
@@ -13,33 +13,46 @@ type ExpressionState<T> = {
  * @param {...ExpressionState<T>[]} catches `catch` expressions
  * @return {T} t
  */
-export const Try = <T>(f: () => T, ...catches: ExpressionState<T>[]): T => {
+export const doOnTry = <T>(f: () => T, ...catches: ExpressionState<T>[]): T => {
   try {
     return f();
   } catch (e) {
-    for (let i = 0; i < catches.length; i++) {
-      const expr = catches[i];
-      if (e instanceof expr.e) {
-        return expr.f(e);
-      }
+    if (!(e instanceof Error)) {
+      throw e;
     }
-    throw e;
+
+    return catches
+        .find((c) => c.e.name === e.name)
+        .f(e);
   }
 };
 
 /**
  * `catch` expression. This function enclose target error type
  * and error handler.
+ * `doOnTry` expression can handle some `recover` functions like
+ * try-catch statement as we know, written below:
+ * ```
+ * try {
+ *   execute();
+ * } catch (IllegalArgumentException iae) {
+ *   handleIllegalArgumentException();
+ * } catch (FileNotFoundException fnf) {
+ *   handleFileNotFoundException();
+ * } catch (Exception e) {
+ *   handleException();
+ * }
+ * ```
  * @param {Error} e Error type infomation to handle.
  * @param {()} f Consumer to be executed
  * @return {T} Expression state of catch expression.
  */
-export const Catch = <T, E extends Error | Error>(
-  e: {new (): E}, f: (e?: E) => T,
+export const recover = <T, E extends Error>(
+  e: E, f: (e: E) => T,
 )
 : ExpressionState<T> => {
   return {
-    e: typeof e,
+    e: e,
     f: f,
   };
 };

--- a/src/try.ts
+++ b/src/try.ts
@@ -34,8 +34,12 @@ export const Try = <T>(f: () => T, ...catches: ExpressionState<T>[]): T => {
  * @param {()} f Consumer to be executed
  * @return {T} Expression state of catch expression.
  */
-export const Catch = <T>(e: typeof Error, f: (e?: Error) => T)
-: ExpressionState<T> => ({
-    e: e,
+export const Catch = <T, E extends Error | Error>(
+  e: {new (): E}, f: (e?: E) => T,
+)
+: ExpressionState<T> => {
+  return {
+    e: typeof e,
     f: f,
-  });
+  };
+};

--- a/test/try-tests.ts
+++ b/test/try-tests.ts
@@ -1,4 +1,4 @@
-import {Try, Catch} from '../src';
+import {doOnTry, recover} from '../src';
 
 describe('Try tests', () => {
   /**
@@ -11,13 +11,27 @@ describe('Try tests', () => {
     execute(): string {
       throw new Error('');
     }
+    /**
+     * Always throw uri error
+     */
+    executeUri(): string {
+      throw new URIError('');
+    }
   }
 
   it('can catch Error', () => {
-    const s = Try(() => (new ErrorService().execute()),
-        Catch(Error, (e: Error) => ('DEFAULT')));
+    const s = doOnTry(() => (new ErrorService().execute()),
+        recover(Error.prototype, (e: Error) => ('DEFAULT')));
 
     expect(s).toBe('DEFAULT');
+  });
+
+  it('can catch URI Error', () => {
+    const s = doOnTry(() => (new ErrorService().executeUri()),
+        recover(URIError.prototype, (e: URIError) => ('URI Error')),
+        recover(Error.prototype, (e: Error) => ('DEFAULT')));
+
+    expect(s).toBe('URI Error');
   });
 });
 


### PR DESCRIPTION
# Outline
Modification for first release

## Updates
- try.ts
  - rename `Catch` to `recover` since linter always recognize as format error
  - `recover` function argument type